### PR TITLE
Bug/valid token in user request

### DIFF
--- a/src/contracts/user/check-by-id.ts
+++ b/src/contracts/user/check-by-id.ts
@@ -1,0 +1,8 @@
+import { type UserModel } from '@/models'
+import { type Either } from '@/shared/either'
+
+export type CheckUserByIdResponse = Either<Error, UserModel>
+
+export interface CheckUserById {
+  perform: (id: string) => Promise<CheckUserByIdResponse>
+}

--- a/src/controllers/user/register-user/register-user-controller.spec.ts
+++ b/src/controllers/user/register-user/register-user-controller.spec.ts
@@ -1,9 +1,10 @@
-import type { RegisterUser, RegisterUserResponse } from '@/contracts/user'
-import { type RegisterUserData } from '@/entities/user'
 import type { Validation } from '@/contracts'
+import type { RegisterUser, RegisterUserResponse } from '@/contracts/user'
+import { type CheckUserById, type CheckUserByIdResponse } from '@/contracts/user/check-by-id'
+import { type RegisterUserData } from '@/entities/user'
 import { badRequest, noContent, serverError } from '@/helpers/http/http-helpers'
-import type { HttpRequest } from '@/types/http'
 import { left, right, type Either } from '@/shared/either'
+import type { HttpRequest } from '@/types/http'
 import { RegisterUserController } from './register-user-controller'
 
 const makeFakeRequest = (): HttpRequest => ({
@@ -38,17 +39,28 @@ const makeFakeRegisterUser = (): RegisterUser => {
   return new RegisterUserStub()
 }
 
+const makeCheckUserByIdUseCase = (): CheckUserById => {
+  class FakeCheckUserById implements CheckUserById {
+    async perform (id: string): Promise<CheckUserByIdResponse> {
+      return await Promise.resolve(left(new Error('User')))
+    }
+  }
+  return new FakeCheckUserById()
+}
+
 type SutTypes = {
   sut: RegisterUserController
   validationStub: Validation
   registerUserStub: RegisterUser
+  checkUserByIdUseCase: CheckUserById
 }
 
 const makeSut = (): SutTypes => {
   const validationStub = makeValidation()
   const registerUserStub = makeFakeRegisterUser()
-  const sut = new RegisterUserController(validationStub, registerUserStub)
-  return { sut, validationStub, registerUserStub }
+  const checkUserByIdUseCase = makeCheckUserByIdUseCase()
+  const sut = new RegisterUserController(validationStub, registerUserStub, checkUserByIdUseCase)
+  return { sut, validationStub, registerUserStub, checkUserByIdUseCase }
 }
 
 describe('RegisterUserController', () => {
@@ -66,6 +78,13 @@ describe('RegisterUserController', () => {
     )
     const httpResponse = await sut.handle(makeFakeRequest())
     expect(httpResponse).toEqual(badRequest(new Error('any_message')))
+  })
+
+  it('Should return 400 if user already exits', async () => {
+    const { sut, checkUserByIdUseCase } = makeSut()
+    jest.spyOn(checkUserByIdUseCase, 'perform').mockResolvedValue(right({ id: 'valid_id', name: 'John doe', email: 'valid@email.com' }))
+    const httpResponse = await sut.handle(makeFakeRequest())
+    expect(httpResponse).toEqual(badRequest(new Error('User already exits')))
   })
 
   it('Should return 500 if Validation throws', async () => {

--- a/src/controllers/user/register-user/register-user-controller.spec.ts
+++ b/src/controllers/user/register-user/register-user-controller.spec.ts
@@ -82,7 +82,7 @@ describe('RegisterUserController', () => {
 
   it('Should return 400 if user already exits', async () => {
     const { sut, checkUserByIdUseCase } = makeSut()
-    jest.spyOn(checkUserByIdUseCase, 'perform').mockResolvedValue(right({ id: 'valid_id', name: 'John doe', email: 'valid@email.com' }))
+    jest.spyOn(checkUserByIdUseCase, 'perform').mockResolvedValue(right({ id: 'valid_id', name: 'John doe', email: 'valid@email.com', username: 'valid_username' }))
     const httpResponse = await sut.handle(makeFakeRequest())
     expect(httpResponse).toEqual(badRequest(new Error('User already exits')))
   })

--- a/src/controllers/user/register-user/register-user-controller.ts
+++ b/src/controllers/user/register-user/register-user-controller.ts
@@ -23,7 +23,7 @@ export class RegisterUserController implements Controller {
 
       const checkUserById = await this.checkUserById.perform(httpRequest.headers.userId)
 
-      if (checkUserById.isRight()) {
+      if (checkUserById.isRight() && checkUserById.value.username) {
         return badRequest(new Error('User already exits'))
       }
 

--- a/src/controllers/user/register-user/register-user-controller.ts
+++ b/src/controllers/user/register-user/register-user-controller.ts
@@ -1,12 +1,14 @@
 import type { Controller, Validation } from '@/contracts'
 import { type RegisterUser } from '@/contracts/user'
+import { type CheckUserById } from '@/contracts/user/check-by-id'
 import { badRequest, noContent, serverError } from '@/helpers/http/http-helpers'
 import type { HttpRequest, HttpResponse } from '@/types/http'
 
 export class RegisterUserController implements Controller {
   constructor (
     private readonly validation: Validation,
-    private readonly registerUser: RegisterUser
+    private readonly registerUser: RegisterUser,
+    private readonly checkUserById: CheckUserById
   ) {}
 
   async handle (httpRequest: HttpRequest): Promise<HttpResponse> {
@@ -19,11 +21,12 @@ export class RegisterUserController implements Controller {
         return badRequest(validationResult.value)
       }
 
-      if (httpRequest.headers.userId === '6583bd18-c717-466c-b357-ee8b34ca464a') {
+      const checkUserById = await this.checkUserById.perform(httpRequest.headers.userId)
+
+      if (checkUserById.isRight()) {
         return badRequest(new Error('User already exits'))
       }
 
-      console.log('aqui')
       const registerUserResult = await this.registerUser.perform({
         id: httpRequest.headers.userId, ...httpRequest.body
       }, httpRequest.session)

--- a/src/controllers/user/register-user/register-user-controller.ts
+++ b/src/controllers/user/register-user/register-user-controller.ts
@@ -1,5 +1,5 @@
-import { type RegisterUser } from '@/contracts/user'
 import type { Controller, Validation } from '@/contracts'
+import { type RegisterUser } from '@/contracts/user'
 import { badRequest, noContent, serverError } from '@/helpers/http/http-helpers'
 import type { HttpRequest, HttpResponse } from '@/types/http'
 
@@ -19,6 +19,11 @@ export class RegisterUserController implements Controller {
         return badRequest(validationResult.value)
       }
 
+      if (httpRequest.headers.userId === '6583bd18-c717-466c-b357-ee8b34ca464a') {
+        return badRequest(new Error('User already exits'))
+      }
+
+      console.log('aqui')
       const registerUserResult = await this.registerUser.perform({
         id: httpRequest.headers.userId, ...httpRequest.body
       }, httpRequest.session)

--- a/src/factories/controllers/user/register-user-controller-factory.ts
+++ b/src/factories/controllers/user/register-user-controller-factory.ts
@@ -1,11 +1,13 @@
 import { type Controller } from '@/contracts/controller'
 import { RegisterUserController } from '@/controllers/user/register-user/register-user-controller'
+import { makeCheckUserByIdUseCase } from '@/factories/usecases/user/find-user-by-id-usecase-factory'
 import { RegisterUserZodValidation } from '@/validators/user/register/register-user-zod-validation'
 import { makeLogControllerDecorator } from '../../decorators'
 import { makeRegisterUserUseCase } from '../../usecases/user/register-user-usecase-factory'
 
 export const makeRegisterUserController = (): Controller => {
   const validation = new RegisterUserZodValidation()
-  const controller = new RegisterUserController(validation, makeRegisterUserUseCase())
+  const checkUserByIdUseCase = makeCheckUserByIdUseCase()
+  const controller = new RegisterUserController(validation, makeRegisterUserUseCase(), checkUserByIdUseCase)
   return makeLogControllerDecorator(controller)
 }

--- a/src/factories/usecases/user/find-user-by-id-usecase-factory.ts
+++ b/src/factories/usecases/user/find-user-by-id-usecase-factory.ts
@@ -1,0 +1,8 @@
+import { type CheckUserById } from '@/contracts/user/check-by-id'
+import { FindUserByIdPrismaRepo } from '@/infra/database/prisma/data/user/find-user-by-id/find-user-by-id-prisma-repo'
+import { CheckUserByIdUseCase } from '@/usecases/implementations/user/check-user-by-id/check-user-by-id-user-case'
+
+export const makeCheckUserByIdUseCase = (): CheckUserById => {
+  const repository = new FindUserByIdPrismaRepo()
+  return new CheckUserByIdUseCase(repository)
+}

--- a/src/infra/database/prisma/data/user/find-user-by-id/find-user-by-id-prisma-repo.spec.ts
+++ b/src/infra/database/prisma/data/user/find-user-by-id/find-user-by-id-prisma-repo.spec.ts
@@ -1,0 +1,59 @@
+import { Prisma, type PrismaClient } from '@/infra/database/prisma/client'
+import { type UserModel } from '@/models'
+import { type FindUserByIdRepo } from '@/usecases/contracts/db/user/find-user-by-id-repo'
+import { createPrismock } from 'prismock'
+import { PrismaHelper } from '../../../helpers'
+import { FindUserByIdPrismaRepo } from './find-user-by-id-prisma-repo'
+
+const makeFakeUserModel = (): UserModel => ({
+  id: 'any_user_id',
+  email: 'any_email@mail.com',
+  name: 'John Doe',
+  dateOfBirth: new Date()
+})
+
+const PrismockClient = createPrismock(Prisma)
+
+const makeSut = (): FindUserByIdRepo => {
+  return new FindUserByIdPrismaRepo()
+}
+
+let prismock: PrismaClient
+describe('FindUserByIdPrismaRepo', () => {
+  beforeAll(async () => {
+    prismock = new PrismockClient()
+    jest.spyOn(PrismaHelper, 'getPrisma').mockReturnValue(
+      Promise.resolve(prismock)
+    )
+  })
+
+  beforeEach(async () => {
+    await prismock.user.deleteMany()
+  })
+
+  afterAll(async () => {
+    await prismock.$disconnect()
+  })
+
+  it('should return a user if user id exitis', async () => {
+    await prismock.user.create({ data: makeFakeUserModel() })
+    const sut = makeSut()
+    const reponse = await sut.execute('any_user_id')
+    expect(reponse).not.toBeNull()
+  })
+
+  it('Should return null if user not found', async () => {
+    const sut = makeSut()
+    const reponse = await sut.execute('invalid_id')
+    expect(reponse).toBeNull()
+  })
+
+  it('Should throw if Prisma throws', async () => {
+    jest.spyOn(prismock.user, 'findUnique').mockRejectedValue(
+      new Error('any_error_message')
+    )
+    const sut = makeSut()
+    const response = sut.execute('invalid_id')
+    await expect(response).rejects.toThrow(new Error('any_error_message'))
+  })
+})

--- a/src/infra/database/prisma/data/user/find-user-by-id/find-user-by-id-prisma-repo.ts
+++ b/src/infra/database/prisma/data/user/find-user-by-id/find-user-by-id-prisma-repo.ts
@@ -1,0 +1,11 @@
+import { PrismaHelper } from '@/infra/database/prisma/helpers'
+import { type UserModel } from '@/models'
+import { type FindUserByIdRepo } from '@/usecases/contracts/db/user/find-user-by-id-repo'
+
+export class FindUserByIdPrismaRepo implements FindUserByIdRepo {
+  async execute (id: string): Promise<UserModel | null > {
+    const prisma = await PrismaHelper.getPrisma()
+    const userOrNull = await prisma.user.findUnique({ where: { id } })
+    return userOrNull
+  }
+}

--- a/src/routes/user/user-routes.test.ts
+++ b/src/routes/user/user-routes.test.ts
@@ -2,10 +2,10 @@
  * @jest-environment ./src/infra/database/prisma/schema/custom-environment-jest.ts
 */
 
-import type { ExternalAuthMappingModel, PlayerProfileModel } from '@/models'
-import { PrismaHelper } from '@/infra/database/prisma/helpers'
 import { AppModule } from '@/app.module'
 import env from '@/configs/env'
+import { PrismaHelper } from '@/infra/database/prisma/helpers'
+import type { ExternalAuthMappingModel, PlayerProfileModel } from '@/models'
 import { type INestApplication } from '@nestjs/common'
 import { Test } from '@nestjs/testing'
 import type { PrismaClient } from '@prisma/client'
@@ -42,6 +42,7 @@ const makeFakeToken = async (): Promise<string> => {
   const token = jwt.sign({ clerkUserId: 'any_external_auth_user_id' }, env.clerkJwtSecretKey)
   return token
 }
+
 const makeFakePlayerProfile = (): PlayerProfileModel => ({
   id: '9228a9a0-c7e0-4d62-80bb-458dd772c4f9',
   name: 'any_player_profile_name',

--- a/src/usecases/contracts/db/user/find-user-by-id-repo.ts
+++ b/src/usecases/contracts/db/user/find-user-by-id-repo.ts
@@ -1,0 +1,5 @@
+import type { UserModel } from '@/models'
+
+export interface FindUserByIdRepo {
+  execute: (id: string) => Promise<null | UserModel>
+}

--- a/src/usecases/implementations/user/check-user-by-id/check-user-by-id-user-case.spec.ts
+++ b/src/usecases/implementations/user/check-user-by-id/check-user-by-id-user-case.spec.ts
@@ -1,0 +1,49 @@
+import { type CheckUserById } from '@/contracts/user/check-by-id'
+import { type UserModel } from '@/models'
+import { type FindUserByEmailRepo } from '@/usecases/contracts/db/user'
+import { CheckUserByIdUseCase } from './check-user-by-id-user-case'
+
+type MakeSut = {
+  sut: CheckUserById
+  repository: FindUserByEmailRepo
+}
+
+const makeFakeRepository = (): FindUserByEmailRepo => {
+  class FakeFindUserByEmailRepo implements FindUserByEmailRepo {
+    async execute (id: string): Promise<UserModel | null > {
+      return await Promise.resolve({ id: 'valid_id', name: 'John Doe', email: 'valid@email.com' })
+    }
+  }
+  return new FakeFindUserByEmailRepo()
+}
+
+const makeSut = (): MakeSut => {
+  const repository = makeFakeRepository()
+  const sut = new CheckUserByIdUseCase(repository)
+  return {
+    sut,
+    repository
+  }
+}
+
+describe('CheckUserById UseCase', () => {
+  it('should call repository with correct values', async () => {
+    const { sut, repository } = makeSut()
+    const repositoryStub = jest.spyOn(repository, 'execute')
+    await sut.perform('valid')
+    expect(repositoryStub).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return a error if user does not exits', async () => {
+    const { sut, repository } = makeSut()
+    jest.spyOn(repository, 'execute').mockResolvedValueOnce(null)
+    const result = await sut.perform('invalid')
+    expect(result.value).toEqual(new Error('User not found'))
+  })
+
+  it('should return a user if exits', async () => {
+    const { sut } = makeSut()
+    const result = await sut.perform('valid')
+    expect(result.value).toEqual(expect.objectContaining({ id: 'valid_id', name: 'John Doe', email: 'valid@email.com' }))
+  })
+})

--- a/src/usecases/implementations/user/check-user-by-id/check-user-by-id-user-case.ts
+++ b/src/usecases/implementations/user/check-user-by-id/check-user-by-id-user-case.ts
@@ -1,0 +1,15 @@
+import { type CheckUserById, type CheckUserByIdResponse } from '@/contracts/user/check-by-id'
+import { left, right } from '@/shared/either'
+import { type FindUserByIdRepo } from '@/usecases/contracts/db/user/find-user-by-id-repo'
+
+export class CheckUserByIdUseCase implements CheckUserById {
+  constructor (private readonly findUserByIdRepository: FindUserByIdRepo) {}
+
+  async perform (id: string): Promise<CheckUserByIdResponse> {
+    const findUser = await this.findUserByIdRepository.execute(id)
+    if (findUser === null) {
+      return left(new Error('User not found'))
+    }
+    return right(findUser)
+  }
+}


### PR DESCRIPTION
@htamagnus e @emerson-oliveira . Segue a branch referente ao fix: Validação de Token no Payload e Ajuste nos Retornos de Erros da API bug enhancement. 

Realizando essa analise, observei que não da para validar somente pelo usuario, pois o quando o cleck devolve chama o webhook para salvar o usuário para gente, ele já cadastrada o user no bando de dados, com isso não é tão valido validar somente a utilização do token para ver se ele já foi cadastrado, pois  o token, vem como o id do ususario que já foi cadastrado pelo cleack no seu webhook. Com isso o teste adicional que eu fiz foi validar se o usarname do usuário já esta cadastrado se esse username já esta cadastrado então o token já foi utilizado e com isso da um execption.  

Como comentei fiz a implementação validando o usarname, porem minha recomendação seria também deixar esse username obrigatório para o cadastro, pois asssim a validação do token se torna valida. 